### PR TITLE
Use a workaround

### DIFF
--- a/api/test.ts
+++ b/api/test.ts
@@ -1,4 +1,4 @@
-import { name } from '../backend/app'
+import { name } from '../backend/app.js'
 
 export default async function handler(request, response) {
   return response.status(200).send(`Hello, ${name}!`);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,5 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
Technically, Node.js expects ESM projects to have "type" set to "module" in the package.json. In this mode, file extensions are also expected.

The behavior where these are not necessarily is a Vercel feature enabled by compilation of user code. The way we do this in production is a bit different than `vercel dev` for performance and convenience reasons.

You can work around this by changing your code in a similar way to this PR.

We're working on a fix for `vercel dev` to allow this behavior again.